### PR TITLE
Add a new widget JSONCheckbox

### DIFF
--- a/src/components/widgets/JSONCheckbox/JSONCheckbox.stories.tsx
+++ b/src/components/widgets/JSONCheckbox/JSONCheckbox.stories.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { StoryFn, Meta } from "@storybook/react";
+import { JSONCheckbox } from ".";
+
+export default {
+  title: "Work in progress/Widgets/JSONCheckbox/JSONCheckbox",
+  component: JSONCheckbox,
+} as Meta<typeof JSONCheckbox>;
+
+const Template: StoryFn<typeof JSONCheckbox> = (args: any) => (
+  <JSONCheckbox {...args} onChange={(value) => console.log("value", value)} />
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  value: { option_1: false, option_2: true, option_3: false },
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  value: { option_1: false, option_2: true, option_3: false },
+  readOnly: true,
+};

--- a/src/components/widgets/JSONCheckbox/JSONCheckbox.tsx
+++ b/src/components/widgets/JSONCheckbox/JSONCheckbox.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { BaseFieldProps } from "@/components/form";
+import { Checkbox } from "antd";
+
+const humanizeLabel = (key: string): string => {
+  return (
+    key
+      // Reemplaça guions baixos i guions amb espais
+      .replace(/[_-]+/g, " ")
+      // Converteix a majúscules la primera lletra de cada paraula
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ")
+  );
+};
+
+export const JSONCheckbox = (
+  props: BaseFieldProps<Record<string, boolean>>,
+) => {
+  const { readOnly } = props;
+  const [values, setValues] = useState(props.value || {});
+
+  const handleChange = (key: string) => {
+    const newValues = {
+      ...values,
+      [key]: !values[key],
+    };
+    setValues(newValues);
+    if (props.onChange) {
+      props.onChange(newValues);
+    }
+  };
+
+  return (
+    <div>
+      {Object.keys(values).map((key) => (
+        <Checkbox
+          disabled={readOnly}
+          key={key}
+          checked={values[key]}
+          onChange={() => handleChange(key)}
+        >
+          {humanizeLabel(key)}
+        </Checkbox>
+      ))}
+    </div>
+  );
+};

--- a/src/components/widgets/JSONCheckbox/index.ts
+++ b/src/components/widgets/JSONCheckbox/index.ts
@@ -1,0 +1,1 @@
+export * from "./JSONCheckbox";


### PR DESCRIPTION
This widget allows to pass a json like:

```json
{
  "option_1": false,
  "option_2": true,
  "option_3": false
}
```

And will be rendered as:

![image](https://github.com/gisce/react-formiga-components/assets/294235/280907c6-8feb-43cc-914a-1ec855f4905c)

With `onChange` we get the updated value of the json properties