### PR TITLE
Fix optional filename in downloadFile

### DIFF
--- a/src/helpers/fileHelper/fileHelper.ts
+++ b/src/helpers/fileHelper/fileHelper.ts
@@ -47,6 +47,6 @@ export async function downloadFile(value: string, filename?: string) {
   const downloadLink = document.createElement("a");
 
   downloadLink.href = linkSource;
-  downloadLink.download = `download.${fileType?.ext}`;
+  downloadLink.download = filename ?? `download.${fileType?.ext}`;
   downloadLink.click();
 }


### PR DESCRIPTION
## Summary
- use provided filename in `downloadFile`

## Testing
- `npx eslint -c .eslintrc.json src/helpers/fileHelper/fileHelper.ts` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68512a02f914832b9d710f2facf032ba