### PR TITLE
fix: add STOCK_OPEN for folder icon

### DIFF
--- a/src/components/ui/Icon/Icon.tsx
+++ b/src/components/ui/Icon/Icon.tsx
@@ -100,6 +100,7 @@ const iconMapping: { [key: string]: string } = {
   STOCK_CLEAR: "CloseSquare",
   STOCK_UNINDENT: "AlignLeft",
   STOCK_PREFERENCES: "Setting",
+  STOCK_OPEN: "Folder",
 };
 
 function toCamelCase(key: string): string {


### PR DESCRIPTION
This pull request adds a new icon mapping for the `STOCK_OPEN` key in the `iconMapping` object in `Icon.tsx`. This allows the `STOCK_OPEN` icon to be rendered as the `Folder` icon throughout the UI.

- UI Icon Mapping:
  * Added a mapping for the `STOCK_OPEN` key to use the `Folder` icon in the `iconMapping` object in `src/components/ui/Icon/Icon.tsx`